### PR TITLE
Use off-perm bucket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ S3_TEMP_ACCESS_KEY=your_access_key
 S3_TEMP_SECRET_KEY=your_secret_key
 S3_PERM_ACCESS_KEY=your_access_key
 S3_PERM_SECRET_KEY=your_secret_key
+S3_OFF_PERM_ACCESS_KEY=your_access_key
+S3_OFF_PERM_SECRET_KEY=your_secret_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ services:
               "bucket": "asset-perm",
               "access_key_env_var": "S3_PERM_ACCESS_KEY",
               "secret_key_env_var": "S3_PERM_SECRET_KEY"
+            },
+            "off-perm": {
+              "endpoint": "https://rgw.watonomous.ca",
+              "bucket": "asset-off-perm",
+              "access_key_env_var": "S3_OFF_PERM_ACCESS_KEY",
+              "secret_key_env_var": "S3_OFF_PERM_SECRET_KEY"
             }
           }
         }
@@ -34,3 +40,5 @@ services:
       - S3_TEMP_SECRET_KEY=${S3_TEMP_SECRET_KEY:?}
       - S3_PERM_ACCESS_KEY=${S3_PERM_ACCESS_KEY:?}
       - S3_PERM_SECRET_KEY=${S3_PERM_SECRET_KEY:?}
+      - S3_OFF_PERM_ACCESS_KEY=${S3_OFF_PERM_ACCESS_KEY:?}
+      - S3_OFF_PERM_SECRET_KEY=${S3_OFF_PERM_SECRET_KEY:?}


### PR DESCRIPTION
This PR introduces the off-perm bucket to store objects retired from perm.
This bucket is needed because the retired objects from perm may not fit within the temporary bucket's quota.


Requires #1, https://github.com/WATonomous/infra-config/pull/2886

